### PR TITLE
switched relief['maintenance'] to maintenance in relief.true_values

### DIFF
--- a/docassemble/MODivorceForms/data/questions/shared.yml
+++ b/docassemble/MODivorceForms/data/questions/shared.yml
@@ -3012,7 +3012,7 @@ validation code: |
     respondent.maintenance_received = 0
     respondent.maintenance_paid = 0
 ---
-if: not relief['maintenance']
+if: not 'maintenance' in relief.true_values()
 code: |
   is_maintenance_award = False
   petitioner.maintenance_received = 0


### PR DESCRIPTION
If maintenance isn't an option for relief (if the spouse doesn't live in Missouri and the marriage was not in Missouri) then an error was caused when looking for relief['maintenance'].  Switching to 'maintenance' in relief.true_values avoids this error.